### PR TITLE
Add dopamine-driven portfolio theme

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -6,6 +6,7 @@ import Skills from './components/Skills'
 import Education from './components/Education'
 import Resume from './components/Resume'
 import Contact from './components/Contact'
+import PatternInterrupt from './components/PatternInterrupt'
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
       <Education/>
       <Resume/>
       <Contact/>
+      <PatternInterrupt/>
     </>
   )
 }

--- a/app/src/components/About.jsx
+++ b/app/src/components/About.jsx
@@ -1,12 +1,12 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 
 export default function About() {
   return (
     <section id="about" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-4">About Me</motion.h2>
-      <motion.p initial={{opacity:0}} whileInView={{opacity:1}} viewport={{once:true}} className="leading-relaxed text-lg">
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-4">Meet the Mind</Motion.h2>
+      <Motion.p initial={{opacity:0}} whileInView={{opacity:1}} viewport={{once:true}} className="leading-relaxed text-lg">
         AI engineer with hands-on experience building end-to-end intelligent systems. Skilled in integrating React frontends with Python backends and deploying scalable solutions.
-      </motion.p>
+      </Motion.p>
     </section>
   )
 }

--- a/app/src/components/Contact.jsx
+++ b/app/src/components/Contact.jsx
@@ -1,10 +1,10 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 import {FaEnvelope, FaLinkedin, FaGithub} from 'react-icons/fa'
 
 export default function Contact(){
   return (
     <section id="contact" className="py-20 container mx-auto px-4 text-center">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-8">Get in Touch</motion.h2>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-8">Reach Out. Right Now.</Motion.h2>
       <div className="flex justify-center space-x-6 text-3xl">
         <a href="mailto:example@email.com" className="hover:text-cyan-400"><FaEnvelope/></a>
         <a href="https://www.linkedin.com" className="hover:text-cyan-400"><FaLinkedin/></a>

--- a/app/src/components/Education.jsx
+++ b/app/src/components/Education.jsx
@@ -1,10 +1,10 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 
 export default function Education(){
   return (
     <section id="education" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-4">Education</motion.h2>
-      <motion.p initial={{opacity:0}} whileInView={{opacity:1}} viewport={{once:true}} className="text-lg">B.E. in Artificial Intelligence & Machine Learning – GM Institute of Technology, 2020–2024</motion.p>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-4">Credentials</Motion.h2>
+      <Motion.p initial={{opacity:0}} whileInView={{opacity:1}} viewport={{once:true}} className="text-lg">B.E. in Artificial Intelligence & Machine Learning – GM Institute of Technology, 2020–2024</Motion.p>
     </section>
   )
 }

--- a/app/src/components/Experience.jsx
+++ b/app/src/components/Experience.jsx
@@ -1,4 +1,4 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 
 const experiences = [
   {role:'AI Engineer',company:'SLK Software',period:'2023-2024',details:['Developed generative slide deck creator','Integrated React with FastAPI','Deployed pipelines on Vertex AI']},
@@ -8,10 +8,10 @@ const experiences = [
 export default function Experience(){
   return (
     <section id="experience" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-8">Experience</motion.h2>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-8">Battle Scars</Motion.h2>
       <div className="space-y-6">
         {experiences.map((exp,idx)=> (
-          <motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="bg-gray-800 p-4 rounded-md">
+          <Motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="bg-gray-800 p-4 rounded-md">
             <div className="flex justify-between items-center">
               <h3 className="text-xl font-medium">{exp.role} - {exp.company}</h3>
               <span className="text-sm text-gray-400">{exp.period}</span>
@@ -19,7 +19,7 @@ export default function Experience(){
             <ul className="list-disc list-inside ml-4 mt-2 text-sm text-gray-300">
               {exp.details.map((d,i)=>(<li key={i}>{d}</li>))}
             </ul>
-          </motion.div>
+          </Motion.div>
         ))}
       </div>
     </section>

--- a/app/src/components/Hero.jsx
+++ b/app/src/components/Hero.jsx
@@ -1,16 +1,16 @@
-import {motion} from 'framer-motion'
-import {FaDownload} from 'react-icons/fa'
+import {motion as Motion} from 'framer-motion'
+import {FaBolt} from 'react-icons/fa'
 
 export default function Hero() {
   return (
-    <section id="hero" className="min-h-screen flex flex-col items-center justify-center text-center space-y-6" >
-      <motion.h1 initial={{opacity:0, y:-20}} animate={{opacity:1, y:0}} transition={{duration:0.8}} className="text-4xl md:text-5xl font-bold">V. Sri Krishna Deva Rayudu</motion.h1>
-      <motion.p initial={{opacity:0}} animate={{opacity:1}} transition={{delay:0.4, duration:0.8}} className="text-xl md:text-2xl text-cyan-400">Full-Stack AI Engineer specializing in Generative AI</motion.p>
-      <motion.div initial={{opacity:0, scale:0.8}} animate={{opacity:1, scale:1}} transition={{delay:0.8}}>
-        <a href="/Resume.pdf" className="inline-flex items-center px-4 py-2 bg-cyan-600 hover:bg-cyan-500 rounded-md text-white" download>
-          <FaDownload className="mr-2"/> Download Resume
+    <section id="hero" className="min-h-screen flex flex-col items-center justify-center text-center space-y-6 bg-gradient-to-b from-black via-gray-900 to-black">
+      <Motion.h1 initial={{opacity:0, y:-20}} animate={{opacity:1, y:0}} transition={{duration:0.8}} className="neon text-4xl md:text-5xl font-extrabold text-cyan-400">Crave the Future</Motion.h1>
+      <Motion.p initial={{opacity:0}} animate={{opacity:1}} transition={{delay:0.4, duration:0.8}} className="text-xl md:text-2xl text-gray-300">Scroll once. Want more.</Motion.p>
+      <Motion.div initial={{opacity:0, scale:0.8}} animate={{opacity:1, scale:1}} transition={{delay:0.8}}>
+        <a href="#projects" className="inline-flex items-center px-6 py-3 bg-cyan-600 hover:bg-cyan-500 rounded-md text-white font-semibold animate-pulse" >
+          <FaBolt className="mr-2"/> Can't Resist
         </a>
-      </motion.div>
+      </Motion.div>
     </section>
   )
 }

--- a/app/src/components/PatternInterrupt.jsx
+++ b/app/src/components/PatternInterrupt.jsx
@@ -1,0 +1,20 @@
+import {useEffect, useState} from 'react'
+import {motion as Motion} from 'framer-motion'
+
+export default function PatternInterrupt() {
+  const [show, setShow] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setShow(true), 5000)
+    return () => clearTimeout(t)
+  }, [])
+  if (!show) return null
+  return (
+    <Motion.div initial={{opacity:0}} animate={{opacity:1}} className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
+      <Motion.div initial={{scale:0.8}} animate={{scale:1}} className="bg-gray-900 border border-cyan-400 p-8 rounded-md text-center space-y-4 shadow-xl">
+        <h3 className="text-2xl font-bold text-cyan-400">Ready to Level Up?</h3>
+        <p className="text-gray-200">Hit the button and let's build something unforgettable.</p>
+        <a href="#contact" className="inline-block px-6 py-3 bg-cyan-600 hover:bg-cyan-500 rounded-md text-white font-semibold">I'm In</a>
+      </Motion.div>
+    </Motion.div>
+  )
+}

--- a/app/src/components/Projects.jsx
+++ b/app/src/components/Projects.jsx
@@ -1,4 +1,4 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 
 const projects = [
   {title:'AI Slide Generator Agent',desc:'Automated PowerPoint creation using Generative AI.'},
@@ -9,13 +9,13 @@ const projects = [
 export default function Projects() {
   return (
     <section id="projects" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-8">Projects</motion.h2>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-8">Obsession-Worthy Builds</Motion.h2>
       <div className="grid md:grid-cols-3 gap-6">
         {projects.map((p,idx)=>(
-          <motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="bg-gray-800 p-4 rounded-md shadow">
+          <Motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="bg-gray-800 p-4 rounded-md shadow">
             <h3 className="text-xl font-medium mb-2">{p.title}</h3>
             <p className="text-sm text-gray-300">{p.desc}</p>
-          </motion.div>
+          </Motion.div>
         ))}
       </div>
     </section>

--- a/app/src/components/Resume.jsx
+++ b/app/src/components/Resume.jsx
@@ -1,9 +1,9 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 
 export default function Resume(){
   return (
     <section id="resume" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-4">Resume</motion.h2>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-4">The Proof</Motion.h2>
       <div className="w-full h-96">
         <iframe src="/Resume.pdf" className="w-full h-full border" title="Resume"></iframe>
       </div>

--- a/app/src/components/Skills.jsx
+++ b/app/src/components/Skills.jsx
@@ -1,4 +1,4 @@
-import {motion} from 'framer-motion'
+import {motion as Motion} from 'framer-motion'
 import {SiPython,SiReact,SiTensorflow,SiFastapi} from 'react-icons/si'
 
 const skills=[
@@ -11,15 +11,15 @@ const skills=[
 export default function Skills(){
   return (
     <section id="skills" className="py-20 container mx-auto px-4">
-      <motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="text-3xl font-semibold mb-8">Skills</motion.h2>
+      <Motion.h2 initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="neon text-3xl font-semibold mb-8">My Toolset</Motion.h2>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
         {skills.map((s,idx)=> {
           const Icon=s.icon
           return (
-            <motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="flex flex-col items-center bg-gray-800 p-4 rounded-md">
+            <Motion.div key={idx} initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="flex flex-col items-center bg-gray-800 p-4 rounded-md">
               <Icon className="text-3xl text-cyan-400"/>
               <span className="mt-2 text-sm">{s.label}</span>
-            </motion.div>
+            </Motion.div>
           )
         })}
       </div>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -3,5 +3,9 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-900 text-gray-200 font-sans;
+  @apply bg-black text-gray-200 font-sans overflow-x-hidden;
+}
+
+.neon {
+  text-shadow: 0 0 10px #06b6d4, 0 0 20px #06b6d4;
 }


### PR DESCRIPTION
## Summary
- implement dark neon theme with "neon" text style
- add a PatternInterrupt overlay component that appears after delay
- update headings and copy to hook the user
- refactor Framer Motion imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f850342908331bc44110210539bf1